### PR TITLE
[ENH] Add option to display Qhub version 

### DIFF
--- a/qhub_jupyterhub_theme/templates/page.html
+++ b/qhub_jupyterhub_theme/templates/page.html
@@ -25,6 +25,14 @@
 {% endif %}
 {% endblock %}
 
+{% block footer %}
+{% if display_version %}
+<div class="version">
+  {{ version or 'v0.0.1'}}
+</span>
+{% endif %}
+{% endblock %}
+
 {% block stylesheet %}
 <link rel="stylesheet" href="{{ static_url("css/style.min.css") }}" type="text/css"/>
 <style>
@@ -39,7 +47,7 @@
   {% for jsurl in jsurls %}
   <script type="text/javascript" src="{{ jsurl }}" defer></script>
   {% endfor %}
-  
+
 {% endblock %}
 
 {# requires jupyerhub > 0.9.4 https://github.com/jupyterhub/jupyterhub/pull/2296 #} {% block logo %}

--- a/qhub_jupyterhub_theme/templates/style.css
+++ b/qhub_jupyterhub_theme/templates/style.css
@@ -66,3 +66,17 @@
     vertical-align: top !important;
     padding-top: 60px;
 }
+
+.version {
+    position: fixed;
+    bottom: 20px; /* Place the button at the bottom of the page */
+    right: 30px; /* Place the button 30px from the right */
+    z-index: 99; /* Make sure it does not overlap */
+    width: 100px;
+    padding: 5px;
+    background: none;
+    color: {{ primary_color | default("#4f4173") }};
+    text-align: center;
+    font-size: 16px; /* Increase font size */
+    font-family: "Panton Black Caps";
+  }

--- a/qhub_jupyterhub_theme/templates/style.css
+++ b/qhub_jupyterhub_theme/templates/style.css
@@ -79,4 +79,5 @@
     text-align: center;
     font-size: 16px; /* Increase font size */
     font-family: "Panton Black Caps";
+    word-wrap: break-word;
   }

--- a/test_jupyterhub_config.py
+++ b/test_jupyterhub_config.py
@@ -26,5 +26,6 @@ c.JupyterHub.template_vars = {
     'h2_color': "#652e8e",
     'navbar_text_color': '#E8E8E8',
     'narbar_hover_color': '#00a3b0',
+    # 'display_version': 'True',
     # 'qhub_theme_extra_js_urls': ['https://google.com/qhub.js']
 }


### PR DESCRIPTION
This PR includes two new optional args to the theme configuration `version_display` (bool) and `version` (str) to be passed over to all pages on Jupyterub. This will open the possibility to pass over the current version of the running instance of qhub.

![image](https://user-images.githubusercontent.com/51954708/164090126-d04758ca-3b5c-4525-8945-27439bcfca08.png)
