### PR TITLE
[ENH] Move displayed version to left

### DIFF
--- a/qhub_jupyterhub_theme/templates/style.css
+++ b/qhub_jupyterhub_theme/templates/style.css
@@ -70,7 +70,7 @@
 .version {
     position: fixed;
     bottom: 20px; /* Place the button at the bottom of the page */
-    right: 30px; /* Place the button 30px from the right */
+    left: 30px; /* Place the button 30px from the left */
     z-index: 99; /* Make sure it does not overlap */
     width: 100px;
     padding: 5px;


### PR DESCRIPTION
This is a corrective maneuver to avoid conflicting positioning with the different custom extensions of the `qhub-jupyterhub-theme` pages, as for instance, when using the `cdsdashboards` theme, the new-dashboards help buttons conflict in place with the original position of the displayed version.

- This PR simply moves the version from `right` to `left`.